### PR TITLE
small fixes and add support for noblock pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you're a consumer you can just use the convenience `consume` method.
 */
 $callback = function ($event) use ($q) {
     // do anything or nothing at all
-    return Okq::STATUS_ACK;
+    return Okq::EVENT_ACK;
 };
 $timeout = 30;
 $q->consume($callback, array('testQueue'), $timeout);

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ of the okQ command itself. The `Okq` class extends [phpredis/Redis](https://gith
 and can be constructed using the same arguments:
 
 ```PHP
-$q = new Okq('127.0.0.1');
+$q = new Okq();
+$q->connect('127.0.0.1', 4777);
 ```
 
 Then to add jobs you just run the command!
@@ -34,9 +35,9 @@ If you're a consumer you can just use the convenience `consume` method.
  - array('StaticClass', 'funcName')
  - array($obj, 'funcName')
  - 'funcName'
- - create_function('$queue,$event', '...')
+ - create_function('$event', '...')
 */
-$callback = function ($queue, $event) use ($q) {
+$callback = function ($event) use ($q) {
     // do anything or nothing at all
     return Okq::STATUS_ACK;
 };

--- a/okq/Okq.php
+++ b/okq/Okq.php
@@ -2,9 +2,9 @@
 
 class Okq extends Redis
 {
-    const EVENT_ACK = 'ack';
-    const EVENT_NOACK = 'noack';
-    const EVENT_STOP = 'stop';
+    const EVENT_ACK = 1;
+    const EVENT_NOACK = 2;
+    const EVENT_STOP = 4;
 
     private function doPush($queue, $eventId, $contents, $noBlock, $pushRight = false)
     {
@@ -146,19 +146,14 @@ class Okq extends Redis
             }
 
             $response = call_user_func($callback, $event);
-            switch ($response) {
-                case self::EVENT_ACK:
-                    if (isset($event['id'])) {
-                        $eventId = (string)$event['id'];
-                        $this->qack($queue, $eventId);
-                    }
-                    break;
-                case self::EVENT_STOP:
-                    $continue = false;
-                    break;
-                case self::EVENT_NOACK:
-                default:
-                    break;
+            if (($response & self::EVENT_ACK) === self::EVENT_ACK) {
+                if (isset($event['id'])) {
+                    $eventId = (string)$event['id'];
+                    $this->qack($queue, $eventId);
+                }
+            }
+            if (($response & self::EVENT_STOP) === self::EVENT_STOP) {
+                $continue = false;
             }
         }
 


### PR DESCRIPTION
I also changed the callback function to only take in a single argument which is an assoc-array with all the info we want to give the consumer on it. Before it was a queue name and an array which had the id and the contents; with this way there's less to think about and we can easily add more stuff in the future without breaking anything.
